### PR TITLE
SNOW-1455266 - Triton Remove Git Package with CVEs

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -69,7 +69,7 @@ RUN CUDAFLAGS="-include stdio.h" cmake \
     rm /workspace/build/fastertransformer_backend/build/lib/lib*Backend.so -rf
 
 # Removing git because of CVEs, no longer needed after build
-RUN apt-get remove git git-man -y && \
+RUN apt-get purge git git-man -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG TRITON_VERSION=24.09
+ARG TRITON_VERSION=23.05
 ARG BASE_IMAGE=nvcr.io/nvidia/tritonserver:${TRITON_VERSION}-py3
 FROM ${BASE_IMAGE}
 
@@ -67,6 +67,11 @@ RUN CUDAFLAGS="-include stdio.h" cmake \
     CUDAFLAGS="-include stdio.h" make -O -j"$(grep -c ^processor /proc/cpuinfo)" install && \
     rm /workspace/build/fastertransformer_backend/build/bin/*_example -rf && \
     rm /workspace/build/fastertransformer_backend/build/lib/lib*Backend.so -rf
+
+# Removing git because of CVEs, no longer needed after build
+RUN apt-get remove git git-man -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV NCCL_LAUNCH_MODE=GROUP
 ENV WORKSPACE /workspace

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG TRITON_VERSION=23.05
+ARG TRITON_VERSION=24.09
 ARG BASE_IMAGE=nvcr.io/nvidia/tritonserver:${TRITON_VERSION}-py3
 FROM ${BASE_IMAGE}
 


### PR DESCRIPTION
Removes `git` and `git-man` packages which have these CVES:

Vulns:

[CVE-2024-32002](https://nvd.nist.gov/vuln/detail/CVE-2024-32002) (Medium), Packages: pkg:deb/ubuntu/git-man@1:2.34.1-1ubuntu1.9?arch=all&upstream=git&distro=ubuntu-22.04

[CVE-2024-32004](https://nvd.nist.gov/vuln/detail/CVE-2024-32004) (Medium), Packages: pkg:deb/ubuntu/git-man@1:2.34.1-1ubuntu1.9?arch=all&upstream=git&distro=ubuntu-22.04

[CVE-2024-32020](https://nvd.nist.gov/vuln/detail/CVE-2024-32020) (Medium), Packages: pkg:deb/ubuntu/git-man@1:2.34.1-1ubuntu1.9?arch=all&upstream=git&distro=ubuntu-22.04

[CVE-2024-32021](https://nvd.nist.gov/vuln/detail/CVE-2024-32021) (Medium), Packages: pkg:deb/ubuntu/git-man@1:2.34.1-1ubuntu1.9?arch=all&upstream=git&distro=ubuntu-22.04

[CVE-2024-32465](https://nvd.nist.gov/vuln/detail/CVE-2024-32465) (Medium), Packages: pkg:deb/ubuntu/git-man@1:2.34.1-1ubuntu1.9?arch=all&upstream=git&distro=ubuntu-22.04

I built/deployed this image here: https://github.com/snowflakedb/corvo-config/pull/3894/files
And this jenkins smoke test tested triton passed: https://ci-dev-163.int.snowflakecomputing.com/job/K8S/job/corvo/job/smoketest/137/pipeline-graph/
